### PR TITLE
Fix audio issue and show error message in native version of Box64Droid

### DIFF
--- a/scripts/testing/box64droid
+++ b/scripts/testing/box64droid
@@ -33,13 +33,13 @@ then
 	else
 	        cp $PREFIX/glibc/opt/Box64Droid.conf $folder/
 	fi
-	. $folder/Box64Droid.conf
-	. $folder/DXVK_D8VK_HUD.conf
 	echo "Configuration check completed"
 	echo "Starting Termux-x11..."
 	termux-x11 :0 &>/dev/null & pulseaudio --start --load="module-native-protocol-tcp auth-ip-acl=127.0.0.1 auth-anonymous=1" --exit-idle-time=-1 &>/dev/null & sleep 1
 	echo ""
 	echo -e "Termux-x11 started"
+	. $folder/Box64Droid.conf
+	. $folder/DXVK_D8VK_HUD.conf
 	clear
 	echo "Box64Droid by Ilya114, Glory to Ukraine!"
 	echo "Select to start:"
@@ -51,9 +51,12 @@ then
 		. start-box64
 	elif [ $choice = 2 ]
 	then
+		pkill -f "app_process / com.termux.x11"
+		pkill -f pulseaudio
 		exit
 	else
 		echo "Wrong option"
+		sleep 1
 		. box64droid
 	fi
 elif [ $1 = "--uninstall" ]

--- a/scripts/testing/start-box64
+++ b/scripts/testing/start-box64
@@ -25,6 +25,7 @@ then
 	. $PREFIX/bin/box64droid
 else
 		echo "Incorrect resolution"
+		sleep 0.5
 		clear
 		. $PREFIX/bin/start-box64
 	fi
@@ -33,5 +34,5 @@ echo "Launching Termux-X11..."
 am start -n com.termux.x11/com.termux.x11.MainActivity &>/dev/null
 read -p "" yn
 case $yn in
-       	[1]* ) echo " Stopping Wine...";box64 wineserver -k &>/dev/null;echo "";echo " Stopping Termux-X11...";pkill -f "app_process / com.termux.x11";echo ""
+       	[1]* ) echo " Stopping Wine...";box64 wineserver -k &>/dev/null;echo "";echo " Stopping Termux-X11...";pkill -f pulseaudio;pkill -f "app_process / com.termux.x11";echo ""
 esac


### PR DESCRIPTION
The native version of Box64Droid has an issue of no sound. This solves the issue by loading the Box64Droid.conf after running pulseaudio. Also add a delay after entering a wrong number selection to show error message properly.